### PR TITLE
Networking: add wireguard

### DIFF
--- a/home/neovim.nix
+++ b/home/neovim.nix
@@ -29,7 +29,7 @@ in
       vim-elixir
       #comment-nvim # crashes on launch with 22.05
       #which-key-nvim # stopped working with 22.05
-      aw-watcher-vim
+      aw-watcher-vim # TODO: remove from router
     ];
 
     extraConfig = ''

--- a/sys/core.nix
+++ b/sys/core.nix
@@ -8,6 +8,7 @@
     ./fwupd.nix
     ./tmux.nix
     ./zsh.nix
+    ./wireguard.nix
   ];
 
   config.home-manager.users.johanan.programs.git = {

--- a/sys/server.nix
+++ b/sys/server.nix
@@ -20,6 +20,6 @@
 
   nix.gc = {
     automatic = true;
-    dates = "weekly";
+    dates = "daily";
   };
 }

--- a/sys/wireguard.nix
+++ b/sys/wireguard.nix
@@ -1,0 +1,52 @@
+{ config, pkgs, lib, ... }:
+let
+  port = "666";
+  wg_subnet = "10.66.66";
+  private_subnet = "10.77.77";
+in
+{
+  networking.wg-quick.interfaces =
+    if config.networking.hostName == "router" then {
+      wg0 = {
+        address = [ "${wg_subnet}.1/32" ];
+        listenPort = lib.strings.toInt (port);
+        privateKeyFile = "/home/johanan/os/secrets/wireguard-private.key";
+
+        peers = [
+          {
+            # Lenovo P1
+            publicKey = "UpbNJCv+/TVcdYUU8fAgaO6WWAakzuPliYY3OccVeX4=";
+            presharedKeyFile = "/home/johanan/os/secrets/wireguard-psk-lenovop1.key";
+            allowedIPs = [
+              "${wg_subnet}.2/32"
+            ];
+          }
+          {
+            # Pixel 4a
+            publicKey = "2YBkwoob9RpYxN6JH5YLGJ8j2wUhE1AQ1YLEMEvBlV4=";
+            presharedKeyFile = "/home/johanan/os/secrets/wireguard-psk-pixel4a.key";
+            allowedIPs = [
+              "${wg_subnet}.3/32"
+            ];
+          }
+        ];
+      };
+    } else if config.networking.hostName == "voidm" then {
+      wg0 = {
+        address = [ "${wg_subnet}.2/32" ];
+        privateKeyFile = "/home/johanan/os/secrets/wireguard-private.key";
+        dns = [ "${private_subnet}.1" ];
+
+        peers = [
+          {
+            # Router
+            publicKey = "+52L7ozWbO40agAyfGO1rupLp532gYUNuv5xDoNkHjI=";
+            presharedKeyFile = "/home/johanan/os/secrets/wireguard-psk-router.key";
+            allowedIPs = [ "${wg_subnet}.1/32" "${private_subnet}.1/24" ];
+            endpoint = "vpn.skogsbrus.xyz:${port}";
+            persistentKeepalive = 25;
+          }
+        ];
+      };
+    } else { };
+}


### PR DESCRIPTION
This commit adds a wireguard server to run on the router, configuring
`router` and `voidm` as peers.

Intent is for my local LAN to be available by all my devices, regardless
of where they are.

Changelog:
- Add sensible DNS optoins (bogus-priv, no-resolv)
- Enable local hostnames on LAN (<host>.home)
- Improve firewall security: specify ports per interface instead of
  globally
- Daily GC for servers

Future work:
- Use external VPN for outbound connections from the router